### PR TITLE
Keybindings update for Windows & Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,24 @@ To remove console.logs:
 * Press Cmd+Shift+D
 * This will delete all console.log statements in the current document
 
+## Keybindings
+
+Default keybindings for all platforms:
+
+|              Command              |     Mac     |   Windows   |    Linux     |   Default    |
+| :-------------------------------: | :---------: | :---------: | :----------: | :----------: |
+| Insert console.log | shift+cmd+l | shift+win+l | shift+meta+l | shift+ctrl+l |
+| Delete all console.log | shift+cmd+d | shift+win+d | shift+meta+d | shift+ctrl+d |
+
+Above shortcuts can be easily customised via the `keybindings.json` file.
+
+| Command                           | Command ID                       |
+| :-------------------------------- | -------------------------------- |
+| Insert console.log             | extension.insertLogStatement     |
+| Delete all console.log | extension.deleteAllLogStatements |
+
+More details about customising shortcuts can be found in [VS Code documentation](http://code.visualstudio.com/docs/getstarted/keybindings#_customizing-shortcut)
+
 ## To Do
 * Add support for other console.* methods (warn, error, time, timeEnd, etc)
 * Add ability to delete console.* across project (currently just the open file)

--- a/package.json
+++ b/package.json
@@ -31,12 +31,16 @@
             {
                 "command": "extension.insertLogStatement",
                 "key": "shift+ctrl+l",
+                "linux": "shift+meta+l",
+                "win": "shift+win+l",
                 "mac": "shift+cmd+l",
                 "when": "editorTextFocus"
             },
             {
                 "command": "extension.deleteAllLogStatements",
                 "key": "shift+ctrl+d",
+                "linux": "shift+meta+d",
+                "win": "shift+win+d",
                 "mac": "shift+cmd+d"
             }
         ]


### PR DESCRIPTION
This extension keybindings are duplicating the default one provided by VS Code, therefore they are not working correctly on other platforms than Mac. I added not conflicting shortcuts for Windows and Linux.

Note: One thing worth considering is changing both command id's prefix to something more specific.
` extension.insertLogStatement` could become `console-utils.insertLogStatement`. 
Possibly it could be breaking change for peoples who already are customising theirs shortcuts. 

Related issue: #1 
