### PR TITLE
Escapes single quotes in value names.

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -59,7 +59,7 @@ function activate(context) {
         text
             ? vscode.commands.executeCommand('editor.action.insertLineAfter')
                 .then(() => {
-                    const logToInsert = `console.log('${text}: ', ${text});`;
+                    const logToInsert = `console.log('${text.replace(/'/g,'\\\'')}: ', ${text});`;
                     insertText(logToInsert);
                 })
             : insertText('console.log();');


### PR DESCRIPTION
Currently console logging:
`this.props.document.get('currentDocumentId')`
yields
`console.log('this.props.document.get('currentDocumentId'): ', this.props.document.get('currentDocumentId'));`
which is invalid JS syntax, as the single quotes aren't escaped, instead of 
`console.log('this.props.document.get(\'currentDocumentId\'): ', this.props.document.get('currentDocumentId'));`.

Alternatively single quotes in value names could also be replaced by curly single quotes('), backticks(`), double quotes("), etc...