### PR TITLE
Place cursor inside paranthesis when inserting empty console.log()

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -56,25 +56,22 @@ function activate(context) {
         const selection = editor.selection;
         const text = editor.document.getText(selection);
         const placeholder = "";
+        const emptyInsert = `console.log(${placeholder});`;
         const cursorPlacement = () => {
-            vscode.commands.executeCommand('cursorMove',{to: 'wrappedLineEnd'});
+            // release the selection caused by inserting
+            vscode.commands.executeCommand('cursorMove',{to: 'right', by:'character', value :1});
+            // position the cursor inside the parenthesis
             vscode.commands.executeCommand('cursorMove',{to: 'left', by: 'character', value :2});
         };
 
         text
-            ? vscode.commands.executeCommand('editor.action.insertLineAfter')
-                .then(() => {
-                    const logToInsert = `console.log('${text}: ', ${text});`;
-                    insertText(logToInsert);
-                })
-            : vscode.commands.executeCommand('editor.action.insertLineAfter')
-                .then(() => {
-                    const emptyInsert = `console.log(${placeholder});`;
-                    insertText(emptyInsert);
-                })
-                .then(() => {
-                    cursorPlacement();
-                })
+        ? vscode.commands.executeCommand('editor.action.insertLineAfter')
+        .then(() => {
+            const logToInsert = `console.log('${text}: ', ${text});`;
+            insertText(logToInsert);
+        })
+        : insertText(emptyInsert);
+          cursorPlacement();
 
     });
     context.subscriptions.push(insertLogStatement);

--- a/extension.js
+++ b/extension.js
@@ -55,6 +55,11 @@ function activate(context) {
 
         const selection = editor.selection;
         const text = editor.document.getText(selection);
+        const placeholder = "";
+        const cursorPlacement = () => {
+            vscode.commands.executeCommand('cursorMove',{to: 'wrappedLineEnd'});
+            vscode.commands.executeCommand('cursorMove',{to: 'left', by: 'character', value :2});
+        };
 
         text
             ? vscode.commands.executeCommand('editor.action.insertLineAfter')
@@ -62,7 +67,14 @@ function activate(context) {
                     const logToInsert = `console.log('${text}: ', ${text});`;
                     insertText(logToInsert);
                 })
-            : insertText('console.log();');
+            : vscode.commands.executeCommand('editor.action.insertLineAfter')
+                .then(() => {
+                    const emptyInsert = `console.log(${placeholder});`;
+                    insertText(emptyInsert);
+                })
+                .then(() => {
+                    cursorPlacement();
+                })
 
     });
     context.subscriptions.push(insertLogStatement);


### PR DESCRIPTION
Fixes issue #8 

If you saw the a similar PR from me previously, this one replaces that and fixes a type introduced while attempting to match your formatting.