### PR TITLE
Add support for prefix with selection text

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -19,8 +19,9 @@ const insertText = (val) => {
 
 function getAllLogStatements(document, documentText) {
     let logStatements = [];
-
-    const logRegex = /console.(log|debug|info|warn|error|assert|dir|dirxml|trace|group|groupEnd|time|timeEnd|profile|profileEnd|count)\((.*)\);?/g;
+    const prefix = vscode.workspace.getConfiguration('js-console-utils').prefix;
+    // const logRegex = /console.(log|debug|info|warn|error|assert|dir|dirxml|trace|group|groupEnd|time|timeEnd|profile|profileEnd|count)\((.*)\);?/g;
+    const logRegex = new RegExp(prefix + 'console.(log|debug|info|warn|error|assert|dir|dirxml|trace|group|groupEnd|time|timeEnd|profile|profileEnd|count)\((.*)\);?', 'g');
     let match;
     while (match = logRegex.exec(documentText)) {
         let matchRange =
@@ -55,11 +56,12 @@ function activate(context) {
 
         const selection = editor.selection;
         const text = editor.document.getText(selection);
-
+        const prefix = vscode.workspace.getConfiguration('js-console-utils').prefix;
+        console.log('get prefix configuration of js-console-utils', prefix);
         text
             ? vscode.commands.executeCommand('editor.action.insertLineAfter')
                 .then(() => {
-                    const logToInsert = `console.log('${text}: ', ${text});`;
+                    const logToInsert = `${prefix}console.log('${text}: ', ${text});`;
                     insertText(logToInsert);
                 })
             : insertText('console.log();');

--- a/extension.js
+++ b/extension.js
@@ -55,7 +55,6 @@ function activate(context) {
         const selection = editor.selection;
         const text = editor.document.getText(selection);
         const prefix = vscode.workspace.getConfiguration('js-console-utils').prefix;
-        console.log('get prefix configuration of js-console-utils', prefix);
         text
             ? vscode.commands.executeCommand('editor.action.insertLineAfter')
                 .then(() => {

--- a/extension.js
+++ b/extension.js
@@ -19,9 +19,7 @@ const insertText = (val) => {
 
 function getAllLogStatements(document, documentText) {
     let logStatements = [];
-    const prefix = vscode.workspace.getConfiguration('js-console-utils').prefix;
-    // const logRegex = /console.(log|debug|info|warn|error|assert|dir|dirxml|trace|group|groupEnd|time|timeEnd|profile|profileEnd|count)\((.*)\);?/g;
-    const logRegex = new RegExp(prefix + 'console.(log|debug|info|warn|error|assert|dir|dirxml|trace|group|groupEnd|time|timeEnd|profile|profileEnd|count)\((.*)\);?', 'g');
+    const logRegex = /console.(log|debug|info|warn|error|assert|dir|dirxml|trace|group|groupEnd|time|timeEnd|profile|profileEnd|count)\((.*)\);?/g;
     let match;
     while (match = logRegex.exec(documentText)) {
         let matchRange =
@@ -61,7 +59,7 @@ function activate(context) {
         text
             ? vscode.commands.executeCommand('editor.action.insertLineAfter')
                 .then(() => {
-                    const logToInsert = `${prefix}console.log('${text}: ', ${text});`;
+                    const logToInsert = `console.log('${prefix}${text}: ', ${text});`;
                     insertText(logToInsert);
                 })
             : insertText('console.log();');

--- a/package.json
+++ b/package.json
@@ -17,6 +17,17 @@
     ],
     "main": "./extension",
     "contributes": {
+        "configuration": {
+            "type": "object",
+            "title": "Js console utils configuration",
+            "properties": {
+                "js-console-utils.prefix": {
+                    "type": "string",
+                    "default": "",
+                    "description": "Add prefix before the variable name when printed in console."
+                }
+            }
+        },
         "commands": [
             {
                 "command": "extension.insertLogStatement",


### PR DESCRIPTION
The configuration of `js-console-utils.prefix` will add a prefix before the selected text.

This feature can be used when you want to custom the logging text such as `DEBUG-----variable: `.

This PR will not effect the delete function.